### PR TITLE
Improve compiler error message/153

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -56,11 +56,15 @@ Otherwise, incremental compilation might determine there is nothing to compile a
 
 Before committing, don't forget to type
 ```shell
-sbt scalafmtAll scalafixAll
+sbt scalafmtAll scalafixAll scalafmtSbt
 ```
-to format the code and check imports. You can use `pre-commit` hook, provided in `./pre-commit`, to do formating and checking automatically.
+to format the code, .sbt files and check imports. You can use `pre-commit` hook, provided in `./pre-commit`, to do formating and checking automatically.
 
 Additionally, all warnings locally are escalated to errors in CI, so make sure there are none.
+
+### Compatible JDK versions
+
+To build this project successfully, use JDK version 11 or higher. It won't work with lower java versions.
 
 ## Releasing
 

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2021 VirtusLab
+Copyright (c) 2021-2022 VirtusLab
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/build.sbt
+++ b/build.sbt
@@ -3,6 +3,13 @@ import org.scalafmt.sbt.ScalafmtPlugin.autoImport.scalafmtOnCompile
 import sbt.Keys.{semanticdbEnabled, semanticdbVersion, versionScheme}
 import sbt.VirtualAxis.ScalaVersionAxis
 
+initialize ~= { _ =>
+  if (sys.props.getOrElse("java.specification.version", "0").toDouble < 11.0) {
+    throw new IllegalArgumentException(
+      "Project must be built with java version 11 or higher. Current java version will cause failure of compilation.")
+  }
+}
+
 lazy val supportedScalaVersions = List(scalaVersion213, scalaVersion212)
 
 ThisBuild / scalaVersion := supportedScalaVersions.head


### PR DESCRIPTION
1. Added helpful error message for compilation failures caused by using JDK version lower than 11.
2. Updated LICENSE file with 2022 year.