### PR TITLE
optimize codec-registration-serializer-check phase

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -52,6 +52,11 @@ Then, in the target project sbt shell, type `compile`. If the compilation finish
 Remember to type `clean` after successful compilations.
 Otherwise, incremental compilation might determine there is nothing to compile and won't run the plugin you are testing.
 
+### Profiling
+
+To profile akka-serialization-helper compiler plugin used in another project - follow instructions from https://www.lightbend.com/blog/profiling-jvm-applications
+You might as well use any other profiler, but using https://github.com/jvm-profiling-tools/async-profiler with flamegraphs should be really effective and easy to achieve (+ no unexpected bugs / issues / errors).
+
 ### Code quality
 
 Before committing, don't forget to type


### PR DESCRIPTION
Two snippets attached - "old" shows compilation statistics before refactor  and "new" - after refactor (on Hydra).
<img width="817" alt="old_stats_hydra_compilation" src="https://user-images.githubusercontent.com/49597713/170078437-e25c8328-0893-43e3-b4af-7126eb9f6573.png">
<img width="781" alt="new_hydra_compilation_stats" src="https://user-images.githubusercontent.com/49597713/170078477-3d886279-e2ce-475e-8321-8579d4d9362f.png">
