### PR TITLE
Add helpful comments related to false negatives

### DIFF
--- a/circe-akka-serializer/src/main/scala/org/virtuslab/ash/circe/CirceTraitCodec.scala
+++ b/circe-akka-serializer/src/main/scala/org/virtuslab/ash/circe/CirceTraitCodec.scala
@@ -136,6 +136,11 @@ trait CirceTraitCodec[Ser <: AnyRef] extends Codec[Ser] {
     }
   }
 
+  /*
+   * Some types from `foundSerializables` might have not been added to `codecs` sequence.
+   * Such mistakes could lead to runtime errors (as `codecs` sequence is in fact used to define how objects
+   * should be encoded and decoded). That's the reason for this check.
+   */
   private def checkSerializableTypesForMissingCodec(packagePrefix: String): Unit = {
     val reflections = new Reflections(packagePrefix)
     val foundSerializables = reflections.getSubTypesOf(classTag[Ser].runtimeClass).asScala.filterNot(_.isInterface)


### PR DESCRIPTION
Related to #170
Just some helpful comments without changing the logic. This could help in understanding the flow od codec registration checker compiler plugin.