### PR TITLE
Optimize loading time of CirceAkkaSerializer

### DIFF
--- a/README.md
+++ b/README.md
@@ -251,7 +251,9 @@ class ExampleSerializer(actorSystem: ExtendedActorSystem)
   override lazy val packagePrefix = "org.project"
 }
 ```
-`CirceAkkaSerializer` can be configured to use Gzip compression when serializing payloads greater than defined size (default is without compression). See [default reference.conf file](circe-akka-serializer/src/main/resources/reference.conf) with comments for details.
+`CirceAkkaSerializer` can be configured to use Gzip compression when serializing payloads greater than defined size (default is without compression).
+
+See [default reference.conf file](circe-akka-serializer/src/main/resources/reference.conf) with comments for more details about `CirceAkkaSerializer` configuration.
 
 For more guidelines on how to use the serializer,
 read [Akka documentation about serialization](https://doc.akka.io/docs/akka/current/serialization.html),

--- a/circe-akka-serializer/src/main/resources/reference.conf
+++ b/circe-akka-serializer/src/main/resources/reference.conf
@@ -2,6 +2,7 @@
 
 org.virtuslab.ash {
   circe {
+    # enables debug logging
     verbose-debug-logging = off
 
     # Settings for compression of the payload - here we decide, if compression should be possible
@@ -17,5 +18,17 @@ org.virtuslab.ash {
       # the payload will be compressed if its size is bigger than this value.
       compress-larger-than = 32 KiB
     }
+
+    # Enables additional check for missing codec registrations.
+    # This additional check is not needed if codec-registration-checker-compiler-plugin is enabled
+    # and code has been compiled with a 'clean build' (all sources compiled in the same compilation).
+    #
+    # Set this setting to "true" if codec-registration-checker-compiler-plugin is disabled or if you really
+    # need to NOT use the 'clean build' after adding new codec registrations
+    # (there might be some rare corner-cases where codec-registration-checker-compiler-plugin
+    # is not able to find missing codec registrations - but only if sbt incremental compilation is used).
+    #
+    # Beware: enabling this check will cause a negative impact on Circe Akka Serializer performance.
+    enable-missing-codecs-check = false
   }
 }

--- a/circe-akka-serializer/src/main/scala/org/virtuslab/ash/circe/CirceAkkaSerializer.scala
+++ b/circe-akka-serializer/src/main/scala/org/virtuslab/ash/circe/CirceAkkaSerializer.scala
@@ -47,6 +47,7 @@ abstract class CirceAkkaSerializer[Ser <: AnyRef: ClassTag](system: ExtendedActo
   private lazy val log = Logging(system, getClass)
   private lazy val conf = system.settings.config.getConfig("org.virtuslab.ash.circe")
   private lazy val isDebugEnabled = conf.getBoolean("verbose-debug-logging") && log.isDebugEnabled
+  override lazy val shouldDoMissingCodecsCheck: Boolean = conf.getBoolean("enable-missing-codecs-check")
   private lazy val compressionAlgorithm: Compression.Algorithm = conf.getString("compression.algorithm") match {
     case "off" =>
       Compression.Off

--- a/circe-akka-serializer/src/main/scala/org/virtuslab/ash/circe/CirceTraitCodec.scala
+++ b/circe-akka-serializer/src/main/scala/org/virtuslab/ash/circe/CirceTraitCodec.scala
@@ -76,6 +76,8 @@ trait CirceTraitCodec[Ser <: AnyRef] extends Codec[Ser] {
     .toMap
     .withDefaultValue("")
 
+  protected lazy val shouldDoMissingCodecsCheck: Boolean = false
+
   /**
    * Decoder apply method - decodes from Json into an object of type Ser
    */
@@ -120,7 +122,9 @@ trait CirceTraitCodec[Ser <: AnyRef] extends Codec[Ser] {
 
   private def doNeededChecksOnStart(): Unit = {
     checkImplementationForInvalidMemberDeclarations()
-    checkSerializableTypesForMissingCodec(packagePrefix)
+    if (shouldDoMissingCodecsCheck) {
+      checkSerializableTypesForMissingCodec(packagePrefix)
+    }
     checkCodecsForNull()
     checkCodecsForDuplication()
   }

--- a/circe-akka-serializer/src/test/resources/application.conf
+++ b/circe-akka-serializer/src/test/resources/application.conf
@@ -27,5 +27,8 @@ org.virtuslab.ash {
       # the payload will be compressed if it's size is bigger than this value.
       compress-larger-than = 1 KiB  #  value set for testing purposes - do not change
     }
+
+    # Enables additional check for missing codec registrations.
+    enable-missing-codecs-check = true
   }
 }

--- a/circe-akka-serializer/src/test/scala/org/virtuslab/ash/circe/CustomTraitCodec.scala
+++ b/circe-akka-serializer/src/test/scala/org/virtuslab/ash/circe/CustomTraitCodec.scala
@@ -13,5 +13,4 @@ object CustomTraitCodec extends CirceTraitCodec[NotSealedTrait] {
   override lazy val packagePrefix: String = "org.virtuslab.ash"
   override lazy val classTagEvidence: ClassTag[NotSealedTrait] = implicitly[ClassTag[NotSealedTrait]]
   override lazy val errorCallback: String => Unit = x => throw new RuntimeException(x)
-  override lazy val shouldDoMissingCodecsCheck: Boolean = false
 }

--- a/circe-akka-serializer/src/test/scala/org/virtuslab/ash/circe/CustomTraitCodec.scala
+++ b/circe-akka-serializer/src/test/scala/org/virtuslab/ash/circe/CustomTraitCodec.scala
@@ -13,4 +13,5 @@ object CustomTraitCodec extends CirceTraitCodec[NotSealedTrait] {
   override lazy val packagePrefix: String = "org.virtuslab.ash"
   override lazy val classTagEvidence: ClassTag[NotSealedTrait] = implicitly[ClassTag[NotSealedTrait]]
   override lazy val errorCallback: String => Unit = x => throw new RuntimeException(x)
+  override lazy val shouldDoMissingCodecsCheck: Boolean = false
 }


### PR DESCRIPTION
closes #138
- made `checkSerializableTypesForMissingCodec` invocation configurable and disabled by default
- `checkSerializableTypesForMissingCodec` is really time-consuming and affects performance of the Circe Akka Serializer negatively in tests and in runtime 
- `checkSerializableTypesForMissingCodec` is not needed if codec-registration-checker-compiler-plugin is enabled and compilation has been a clean build (not incremental - for part of sources)
- `codec-registration-checker-compiler-plugin`  could be needed for some specific corner cases - as described in #170 - but these are rare situations that will be caught as errors by this compiler plugin in most cases