### PR TITLE
fix secrets for reusable github workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,3 +8,4 @@ on:
 jobs:
   run-scala-ci-standard:
     uses: ./.github/workflows/standard-workflow.yml
+    secrets: inherit

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -8,6 +8,7 @@ on:
 jobs:
   run-scala-ci-release:
     uses: ./.github/workflows/standard-workflow.yml
+    secrets: inherit
 
   publish-github-release:
     needs: [run-scala-ci-release]


### PR DESCRIPTION
this change fixes failing `publish-maven-artifacts` job from reusable workflow - example of failed job:  
https://github.com/VirtusLab/akka-serialization-helper/actions/runs/2583960014
