### PR TITLE
Refactor false positives fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -299,7 +299,7 @@ class ExampleSerializer(actorSystem: ExtendedActorSystem)
     // ...
     override lazy val codecs = Seq(Register[CommandOne]) // WHOOPS someone forgot to register CommandTwo...
     // ... but Codec Registration Checker will throw a compilation error here:
-    // `No codec for `CommandOne` is registered in class annotated with @org.virtuslab.ash.annotation.Serializer`
+    // `No codec for `CommandOne` is registered in a class annotated with @org.virtuslab.ash.annotation.Serializer`
 }
 ```
 

--- a/build.sbt
+++ b/build.sbt
@@ -56,8 +56,9 @@ lazy val commonSettings = Seq(
       if (sys.env.getOrElse("CI", "false") == "true") "-Xfatal-warnings" else ""),
   libraryDependencies ++= commonDeps)
 
-// As usage of https://github.com/pathikrit/better-files has been added to the runtime logic of codec-registration-checker-compiler-plugin
-// and dump-persistence-schema-compiler-plugin - this dependency has to be provided within a fat jar when ASH gets published.
+// As usage of https://github.com/pathikrit/better-files and https://github.com/spray/spray-json
+// has been added to the runtime logic of dump-persistence-schema-compiler-plugin -
+// this dependencies have to be provided within a fat jar when ASH gets published.
 // For reasons described in https://github.com/sbt/sbt/issues/2255 - without using fat-jar we would have java.lang.NoClassDefFoundErrors
 lazy val assemblySettings = Seq(
   packageBin / publishArtifact := false, //we want to publish fat jar

--- a/build.sbt
+++ b/build.sbt
@@ -150,7 +150,6 @@ lazy val serializabilityCheckerCompilerPlugin = (projectMatrix in file("serializ
   .jvmPlatform(scalaVersions = supportedScalaVersions)
 
 lazy val codecRegistrationCheckerCompilerPlugin = (projectMatrix in file("codec-registration-checker-compiler-plugin"))
-  .enablePlugins(AssemblyPlugin)
   .settings(name := "codec-registration-checker-compiler-plugin")
   .settings(commonSettings)
   .settings(
@@ -163,8 +162,7 @@ lazy val codecRegistrationCheckerCompilerPlugin = (projectMatrix in file("codec-
         }
         .getOrElse(Seq.empty)
     },
-    libraryDependencies += betterFiles)
-  .settings(assemblySettings: _*)
+    libraryDependencies += betterFiles % Test)
   .dependsOn(annotation, circeAkkaSerializer % Test)
   .jvmPlatform(scalaVersions = supportedScalaVersions)
 

--- a/codec-registration-checker-compiler-plugin/src/main/scala/org/virtuslab/ash/CacheFileInteractionMode.scala
+++ b/codec-registration-checker-compiler-plugin/src/main/scala/org/virtuslab/ash/CacheFileInteractionMode.scala
@@ -1,0 +1,6 @@
+package org.virtuslab.ash
+
+sealed trait CacheFileInteractionMode
+
+case object DumpTypesIntoFile extends CacheFileInteractionMode
+case object RemoveOutdatedTypesFromFile extends CacheFileInteractionMode

--- a/codec-registration-checker-compiler-plugin/src/main/scala/org/virtuslab/ash/CodecRegistrationCheckerCompilerPlugin.scala
+++ b/codec-registration-checker-compiler-plugin/src/main/scala/org/virtuslab/ash/CodecRegistrationCheckerCompilerPlugin.scala
@@ -13,7 +13,6 @@ import scala.tools.nsc.plugins.PluginComponent
 
 import org.virtuslab.ash.CodecRegistrationCheckerCompilerPlugin.directClassDescendantsCacheFileName
 import org.virtuslab.ash.CodecRegistrationCheckerCompilerPlugin.disableFlag
-import org.virtuslab.ash.CodecRegistrationCheckerCompilerPlugin.sourceCodeDirectoryFlag
 
 class CodecRegistrationCheckerCompilerPlugin(override val global: Global) extends Plugin {
   override val name: String = "codec-registration-checker-plugin"
@@ -28,15 +27,6 @@ class CodecRegistrationCheckerCompilerPlugin(override val global: Global) extend
   override def init(options: List[String], error: String => Unit): Boolean = {
     if (options.contains(disableFlag))
       return false
-
-    options.find(flag => flag.contains(sourceCodeDirectoryFlag)) match {
-      case Some(directoryFlag) =>
-        pluginOptions.sourceCodeDirectoryToCheck = directoryFlag.replace(s"$sourceCodeDirectoryFlag=", "")
-      case None =>
-        error(
-          s"Required $sourceCodeDirectoryFlag option has not been set. Please, specify the $sourceCodeDirectoryFlag and retry compilation")
-        return false
-    }
 
     options.filterNot(_.startsWith("-")).headOption match {
       case Some(path) =>
@@ -77,7 +67,6 @@ class CodecRegistrationCheckerCompilerPlugin(override val global: Global) extend
   override val optionsHelp: Option[String] = Some(s"""
       |. - directory where cache file will be saved, required
       |$disableFlag - disables the plugin
-      |$sourceCodeDirectoryFlag - path of the source code directory, which has to be checked with this plugin
       |""".stripMargin)
 
 }
@@ -90,7 +79,6 @@ object CodecRegistrationCheckerCompilerPlugin {
   val serializerType = "org.virtuslab.ash.annotation.Serializer"
 
   val disableFlag = "--disable"
-  val sourceCodeDirectoryFlag = "--source-code-directory"
 
   def parseCacheFile(buffer: ByteBuffer): Seq[ParentChildFQCNPair] = {
     StandardCharsets.UTF_8.decode(buffer).toString.split("\n").toSeq.filterNot(_.isBlank).map(_.split(",")).map {

--- a/codec-registration-checker-compiler-plugin/src/main/scala/org/virtuslab/ash/CodecRegistrationCheckerOptions.scala
+++ b/codec-registration-checker-compiler-plugin/src/main/scala/org/virtuslab/ash/CodecRegistrationCheckerOptions.scala
@@ -21,15 +21,9 @@ import java.io.File
  *   (when `sbt compile` was incremental). And if we can't detect it - this would lead to runtime errors (see README
  *   for more details). `oldParentChildFQCNPairs` gets declared on the plugin's init
  *   by invoking the `CodecRegistrationCheckerCompilerPlugin.parseCacheFile` method.
- *
- * @param sourceCodeDirectoryToCheck - path of the source code directory that hold files with traits and classes
- *   checked by this plugin (i.e. types that are saved into `directClassDescendantsCacheFile`). This parameter is
- *   needed to fix possible false-positives in certain situations.
- *   Check https://github.com/VirtusLab/akka-serialization-helper/issues/141 for details about such false-positives.
  */
 case class CodecRegistrationCheckerOptions(
     var directClassDescendantsCacheFile: File = null,
-    var oldParentChildFQCNPairs: Seq[ParentChildFQCNPair] = null,
-    var sourceCodeDirectoryToCheck: String = null)
+    var oldParentChildFQCNPairs: Seq[ParentChildFQCNPair] = null)
 
 case class ParentChildFQCNPair(parentFQCN: String, childFQCN: String)

--- a/codec-registration-checker-compiler-plugin/src/test/scala/org/virtuslab/ash/CodecRegistrationCheckerCompilerPluginSpec.scala
+++ b/codec-registration-checker-compiler-plugin/src/test/scala/org/virtuslab/ash/CodecRegistrationCheckerCompilerPluginSpec.scala
@@ -12,8 +12,6 @@ class CodecRegistrationCheckerCompilerPluginSpec extends AnyWordSpecLike with sh
   private val dataSourceCode =
     (for (f <- File(getClass.getClassLoader.getResource("data")).children) yield f.contentAsString).toList
 
-  private val sourceCodeDirectory = File(getClass.getClassLoader.getResource(".")).path.toString
-
   private val CORRECT_SERIALIZER_CODE = getSerializerAsString("CorrectSerializer")
   private val EMPTY_SERIALIZER_CODE = getSerializerAsString("EmptySerializer")
   private val INCOMPLETE_SERIALIZER_ONE_CODE = getSerializerAsString("IncompleteSerializer")
@@ -28,7 +26,7 @@ class CodecRegistrationCheckerCompilerPluginSpec extends AnyWordSpecLike with sh
       File.usingTemporaryDirectory() { directory =>
         val out = CodecRegistrationCheckerCompiler.compileCode(
           CORRECT_SERIALIZER_CODE :: dataSourceCode,
-          List(s"${directory.toJava.getAbsolutePath}", s"--source-code-directory=$sourceCodeDirectory"))
+          List(s"${directory.toJava.getAbsolutePath}"))
         out should be("")
       }
     }
@@ -37,7 +35,7 @@ class CodecRegistrationCheckerCompilerPluginSpec extends AnyWordSpecLike with sh
       File.usingTemporaryDirectory() { directory =>
         val out = CodecRegistrationCheckerCompiler.compileCode(
           OBJECT_SERIALIZER_CODE :: dataSourceCode,
-          List(s"${directory.toJava.getAbsolutePath}", s"--source-code-directory=$sourceCodeDirectory"))
+          List(s"${directory.toJava.getAbsolutePath}"))
         out should include("error")
       }
     }
@@ -47,7 +45,7 @@ class CodecRegistrationCheckerCompilerPluginSpec extends AnyWordSpecLike with sh
         File.usingTemporaryDirectory() { directory =>
           val out = CodecRegistrationCheckerCompiler.compileCode(
             EMPTY_SERIALIZER_CODE :: dataSourceCode,
-            List(s"${directory.toJava.getAbsolutePath}", s"--source-code-directory=$sourceCodeDirectory"))
+            List(s"${directory.toJava.getAbsolutePath}"))
           out should include("error")
         }
       }
@@ -56,7 +54,7 @@ class CodecRegistrationCheckerCompilerPluginSpec extends AnyWordSpecLike with sh
         File.usingTemporaryDirectory() { directory =>
           val out = CodecRegistrationCheckerCompiler.compileCode(
             INCOMPLETE_SERIALIZER_ONE_CODE :: dataSourceCode,
-            List(s"${directory.toJava.getAbsolutePath}", s"--source-code-directory=$sourceCodeDirectory"))
+            List(s"${directory.toJava.getAbsolutePath}"))
           out should include("error")
           (out should not).include("literal")
         }
@@ -66,7 +64,7 @@ class CodecRegistrationCheckerCompilerPluginSpec extends AnyWordSpecLike with sh
         File.usingTemporaryDirectory() { directory =>
           val out = CodecRegistrationCheckerCompiler.compileCode(
             INVALID_ANNOTATION_SERIALIZER_CODE :: dataSourceCode,
-            List(s"${directory.toJava.getAbsolutePath}", s"--source-code-directory=$sourceCodeDirectory"))
+            List(s"${directory.toJava.getAbsolutePath}"))
           out should include("error")
         }
       }
@@ -75,7 +73,7 @@ class CodecRegistrationCheckerCompilerPluginSpec extends AnyWordSpecLike with sh
         File.usingTemporaryDirectory() { directory =>
           val out = CodecRegistrationCheckerCompiler.compileCode(
             INVALID_CLASS_SERIALIZER_CODE :: dataSourceCode,
-            List(s"${directory.toJava.getAbsolutePath}", s"--source-code-directory=$sourceCodeDirectory"))
+            List(s"${directory.toJava.getAbsolutePath}"))
           out should include("error")
         }
       }
@@ -84,7 +82,7 @@ class CodecRegistrationCheckerCompilerPluginSpec extends AnyWordSpecLike with sh
         File.usingTemporaryDirectory() { directory =>
           val out = CodecRegistrationCheckerCompiler.compileCode(
             INCOMPLETE_SERIALIZER_TWO_CODE :: dataSourceCode,
-            List(s"${directory.toJava.getAbsolutePath}", s"--source-code-directory=$sourceCodeDirectory"))
+            List(s"${directory.toJava.getAbsolutePath}"))
           out should include("error")
           (out should not).include("literal")
         }
@@ -94,9 +92,7 @@ class CodecRegistrationCheckerCompilerPluginSpec extends AnyWordSpecLike with sh
     "work with no serializer" in {
       File.usingTemporaryDirectory() { directory =>
         val out =
-          CodecRegistrationCheckerCompiler.compileCode(
-            dataSourceCode,
-            List(s"${directory.toJava.getAbsolutePath}", s"--source-code-directory=$sourceCodeDirectory"))
+          CodecRegistrationCheckerCompiler.compileCode(dataSourceCode, List(s"${directory.toJava.getAbsolutePath}"))
         out should be("")
       }
     }
@@ -104,9 +100,7 @@ class CodecRegistrationCheckerCompilerPluginSpec extends AnyWordSpecLike with sh
     "create cache file when missing" in {
       File.usingTemporaryDirectory() { directory =>
         val out =
-          CodecRegistrationCheckerCompiler.compileCode(
-            dataSourceCode,
-            List(s"${directory.toJava.getAbsolutePath}", s"--source-code-directory=$sourceCodeDirectory"))
+          CodecRegistrationCheckerCompiler.compileCode(dataSourceCode, List(s"${directory.toJava.getAbsolutePath}"))
         out should be("")
         val cacheFile =
           (directory / CodecRegistrationCheckerCompilerPlugin.directClassDescendantsCacheFileName).contentAsString
@@ -122,9 +116,7 @@ class CodecRegistrationCheckerCompilerPluginSpec extends AnyWordSpecLike with sh
         val cacheFile = directory / CodecRegistrationCheckerCompilerPlugin.directClassDescendantsCacheFileName
         cacheFile < "org.random.project.SerializableTrait,org.random.project.MissingData"
         val out =
-          CodecRegistrationCheckerCompiler.compileCode(
-            dataSourceCode,
-            List(s"${directory.toJava.getAbsolutePath}", s"--source-code-directory=$sourceCodeDirectory"))
+          CodecRegistrationCheckerCompiler.compileCode(dataSourceCode, List(s"${directory.toJava.getAbsolutePath}"))
         out should be("")
         val cacheFileAfter = cacheFile.contentAsString
         cacheFileAfter should be("""org.random.project.SerializableTrait,org.random.project.GenericData
@@ -141,9 +133,7 @@ class CodecRegistrationCheckerCompilerPluginSpec extends AnyWordSpecLike with sh
           File.usingTemporaryDirectory() { directory =>
             val cacheFile = directory / CodecRegistrationCheckerCompilerPlugin.directClassDescendantsCacheFileName
             cacheFile < "org.random.project.SerializableTrait"
-            CodecRegistrationCheckerCompiler.compileCode(
-              dataSourceCode,
-              List(s"${directory.toJava.getAbsolutePath}", s"--source-code-directory=$sourceCodeDirectory"))
+            CodecRegistrationCheckerCompiler.compileCode(dataSourceCode, List(s"${directory.toJava.getAbsolutePath}"))
           }
         }
       }
@@ -153,7 +143,7 @@ class CodecRegistrationCheckerCompilerPluginSpec extends AnyWordSpecLike with sh
           File.usingTemporaryDirectory() { directory =>
             CodecRegistrationCheckerCompiler.compileCode(
               dataSourceCode,
-              List(s"${directory.toJava.getAbsolutePath}\u0000", s"--source-code-directory=$sourceCodeDirectory"))
+              List(s"${directory.toJava.getAbsolutePath}\u0000"))
           }
         }
       }
@@ -163,21 +153,13 @@ class CodecRegistrationCheckerCompilerPluginSpec extends AnyWordSpecLike with sh
           CodecRegistrationCheckerCompiler.compileCode(dataSourceCode, Nil)
         }
       }
-
-      "--source-code-directory option is not specified" in {
-        assertThrows[RuntimeException] {
-          File.usingTemporaryDirectory() { directory =>
-            CodecRegistrationCheckerCompiler.compileCode(dataSourceCode, List(s"${directory.toJava.getAbsolutePath}"))
-          }
-        }
-      }
     }
 
     "compile with REGISTRATION_REGEX macro" in {
       File.usingTemporaryDirectory() { directory =>
         val out = CodecRegistrationCheckerCompiler.compileCode(
           List(MACRO_REGEX_SERIALIZER_CODE, dataSourceCode.find(_.contains("@SerializabilityTrait")).get),
-          List(s"${directory.toJava.getAbsolutePath}", s"--source-code-directory=$sourceCodeDirectory"))
+          List(s"${directory.toJava.getAbsolutePath}"))
         out should be("")
       }
     }
@@ -191,7 +173,7 @@ class CodecRegistrationCheckerCompilerPluginSpec extends AnyWordSpecLike with sh
           "hydra.test.TestAkkaSerializable,hydra.test.ConcreteClasses")
         val out = CodecRegistrationCheckerCompiler.compileCode(
           CORRECT_SERIALIZER_CODE :: dataSourceCode,
-          List(s"${directory.toJava.getAbsolutePath}", s"--source-code-directory=$sourceCodeDirectory"))
+          List(s"${directory.toJava.getAbsolutePath}"))
         out should be("")
         cacheFile.contentAsString should be("""org.random.project.SerializableTrait,org.random.project.GenericData
                                               |org.random.project.SerializableTrait,org.random.project.IndirectData

--- a/sbt-akka-serialization-helper/src/main/scala/org/virtuslab/ash/AkkaSerializationHelperKeys.scala
+++ b/sbt-akka-serialization-helper/src/main/scala/org/virtuslab/ash/AkkaSerializationHelperKeys.scala
@@ -17,8 +17,6 @@ trait AkkaSerializationHelperKeys {
   lazy val ashCompilerPluginVerbose = settingKey[Boolean]("Prints additional information during compilation")
   lazy val ashCompilerPluginCacheDirectory =
     settingKey[File]("Sets the directory for plugins to store their information")
-  lazy val sourceCodeDirectory =
-    settingKey[String]("Sets the directory for codec-registration-checker-plugin to do additional code check if needed")
 
   lazy val ashDumpPersistenceSchema = taskKey[File]("Dumps schema of classes that are persisted")
   lazy val ashDumpPersistenceSchemaOutputFile = settingKey[File]("Output file to dump persistence schema to")

--- a/sbt-akka-serialization-helper/src/main/scala/org/virtuslab/ash/AkkaSerializationHelperPlugin.scala
+++ b/sbt-akka-serialization-helper/src/main/scala/org/virtuslab/ash/AkkaSerializationHelperPlugin.scala
@@ -1,7 +1,5 @@
 package org.virtuslab.ash
 
-import java.io.File
-
 import sbt.Def
 import sbt.Keys._
 import sbt._
@@ -32,8 +30,7 @@ object AkkaSerializationHelperPlugin extends AutoPlugin {
         compilerPlugin(ashSerializabilityCheckerCompilerPlugin.value)),
     Compile / scalacOptions ++= Seq(
         s"-P:dump-persistence-schema-plugin:${(ashDumpPersistenceSchemaCompilerPlugin / ashCompilerPluginCacheDirectory).value}",
-        s"-P:codec-registration-checker-plugin:${(ashCodecRegistrationCheckerCompilerPlugin / ashCompilerPluginCacheDirectory).value}",
-        s"-P:codec-registration-checker-plugin:${(ashCodecRegistrationCheckerCompilerPlugin / sourceCodeDirectory).value}"),
+        s"-P:codec-registration-checker-plugin:${(ashCodecRegistrationCheckerCompilerPlugin / ashCompilerPluginCacheDirectory).value}"),
     cleanFiles ++= Seq(
         (ashDumpPersistenceSchemaCompilerPlugin / ashCompilerPluginCacheDirectory).value / "dump-persistence-schema-cache",
         (ashCodecRegistrationCheckerCompilerPlugin / ashCompilerPluginCacheDirectory).value / "codec-registration-checker-cache.csv"),
@@ -54,9 +51,7 @@ object AkkaSerializationHelperPlugin extends AutoPlugin {
         new File(
           (ashDumpPersistenceSchema / ashDumpPersistenceSchemaOutputDirectoryPath).value) / (ashDumpPersistenceSchema / ashDumpPersistenceSchemaOutputFilename).value,
       ashDumpPersistenceSchema / ashDumpPersistenceSchemaOutputFilename := s"${name.value}-dump-persistence-schema-${version.value}.yaml",
-      ashDumpPersistenceSchema / ashDumpPersistenceSchemaOutputDirectoryPath := ashCompilerPluginCacheDirectory.value.getPath,
-      ashCodecRegistrationCheckerCompilerPlugin / sourceCodeDirectory := // unfortunately ${scalaSource.value.getAbsolutePath} causes errors, hence long string below
-        s"--source-code-directory=${sourceDirectory.value.getAbsolutePath}${File.separator}main${File.separator}scala") ++
+      ashDumpPersistenceSchema / ashDumpPersistenceSchemaOutputDirectoryPath := ashCompilerPluginCacheDirectory.value.getPath) ++
     Seq(Compile, Test).flatMap(ashScalacOptionsInConfig)
 
   private lazy val ashVersion = getClass.getPackage.getImplementationVersion


### PR DESCRIPTION
Closes #171 

- switched from direct checks on files in user's source code to usage of `global.findMemberFromRoot` method
- stopped relying on better-files in the published code
- stopped publishing fat jars for codec registration checker compiler plugin